### PR TITLE
Fixed missing static assets problem

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@
 #  specific language governing permissions and limitations      *
 #  under the License.                                           *
 
-FROM python:3.6-slim
+FROM python:3.7-slim
 
 ARG AIRFLOW_REPO="apache/airflow"
 ARG AIRFLOW_VERSION="1.10.2"
@@ -52,7 +52,7 @@ RUN apt-get install -y nodejs
 # compile Airflow's static assets
 # NOTE: At this stage `compile_assets.sh` is in `www_rbac`
 #       but Airflow and its assets are in `www`.
-ENV PIP_PACKAGES_PATH="/usr/local/lib/python3.6/site-packages"
+ENV PIP_PACKAGES_PATH="/usr/local/lib/python3.7/site-packages"
 RUN cd ${PIP_PACKAGES_PATH} && ${PIP_PACKAGES_PATH}/airflow/www_rbac/compile_assets.sh && rm -rf ${PIP_PACKAGES_PATH}/airflow/www/node_modules
 
 # remove build deps and Node.js PPA

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,26 +19,49 @@ FROM python:3.6-slim
 
 ARG AIRFLOW_REPO="apache/airflow"
 ARG AIRFLOW_VERSION="1.10.2"
+ARG AIRFLOW_SHA="6418cf5cabf830212892fe5b3f02c43efb316e93"
+
 
 # install deps
 RUN apt-get update -y && apt-get install -y \
     python-dev \
     build-essential \
-    curl \
-    libssl-dev
-
+    libssl-dev \
+    software-properties-common \
+    nodejs \
+    curl
 
 RUN pip install --upgrade pip setuptools
 
 # install airflow
-RUN SLUGIFY_USES_TEXT_UNIDECODE=yes pip install https://github.com/${AIRFLOW_REPO}/archive/${AIRFLOW_VERSION}.zip#egg=apache-airflow[kubernetes,postgres] \
-    fab_oidc==0.0.5 \
-    redis==2.10.6
+ARG AIRFLOW_FILENAME="${AIRFLOW_VERSION}.zip"
+ARG AIRFLOW_TARBALL_URL="https://github.com/${AIRFLOW_REPO}/archive/${AIRFLOW_FILENAME}"
+RUN curl -o ${AIRFLOW_FILENAME} --location ${AIRFLOW_TARBALL_URL} && \
+    echo "${AIRFLOW_SHA}  ${AIRFLOW_FILENAME}" | shasum --check - && \
+    SLUGIFY_USES_TEXT_UNIDECODE=yes pip install file:///./${AIRFLOW_FILENAME}#egg=apache-airflow[kubernetes,postgres] fab_oidc==0.0.6 redis==2.10.6 && \
+    rm ${AIRFLOW_FILENAME}
 
+# install Node.js 10 LTS from official Node.js PPA
+# NOTE: This is required to compile Airflow's static
+#       assets.
+# SEE: This article on how to install node on Debian
+#      https://tecadmin.net/install-latest-nodejs-npm-on-debian/
+RUN curl -sL https://deb.nodesource.com/setup_10.x | bash -
+RUN apt-get install -y nodejs
+
+# compile Airflow's static assets
+# NOTE: At this stage `compile_assets.sh` is in `www_rbac`
+#       but Airflow and its assets are in `www`.
+ENV PIP_PACKAGES_PATH="/usr/local/lib/python3.6/site-packages"
+RUN cd ${PIP_PACKAGES_PATH} && ${PIP_PACKAGES_PATH}/airflow/www_rbac/compile_assets.sh && rm -rf ${PIP_PACKAGES_PATH}/airflow/www/node_modules
+
+# remove build deps and Node.js PPA
 RUN apt-get --purge remove -y \
     build-essential  \
     libssl-dev \
     python-dev \
-    && apt-get clean
+    software-properties-common \
+    nodejs \
+    && apt-get clean && rm /etc/apt/sources.list.d/nodesource.list
 
 ENTRYPOINT ["/usr/local/bin/airflow"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ ARG AIRFLOW_SHA="6418cf5cabf830212892fe5b3f02c43efb316e93"
 
 
 # install deps
-RUN apt-get update -y && apt-get install -y \
+RUN apt-get update -y && apt-get dist-upgrade && apt-get install -y \
     python-dev \
     build-essential \
     libssl-dev \

--- a/Dockerfile
+++ b/Dockerfile
@@ -52,8 +52,8 @@ RUN apt-get install -y nodejs
 # compile Airflow's static assets
 # NOTE: At this stage `compile_assets.sh` is in `www_rbac`
 #       but Airflow and its assets are in `www`.
-ENV PIP_PACKAGES_PATH="/usr/local/lib/python3.7/site-packages"
-RUN cd ${PIP_PACKAGES_PATH} && ${PIP_PACKAGES_PATH}/airflow/www_rbac/compile_assets.sh && rm -rf ${PIP_PACKAGES_PATH}/airflow/www/node_modules
+ENV PYTHON_PIP_SITE_PACKAGES_PATH="/usr/local/lib/python3.7/site-packages"
+RUN cd ${PYTHON_PIP_SITE_PACKAGES_PATH} && ${PYTHON_PIP_SITE_PACKAGES_PATH}/airflow/www_rbac/compile_assets.sh && rm -rf ${PYTHON_PIP_SITE_PACKAGES_PATH}/airflow/www/node_modules
 
 # remove build deps and Node.js PPA
 RUN apt-get --purge remove -y \


### PR DESCRIPTION
Assets needs to be compiled using the [`compile_assets.sh`] script.

This needs Node.js, and that's why we have to add the official
Node.js PPA, see [this article] on how to install Node.js on Debian.

**NOTE**: The [`compile_assets.sh`] script is relying on the fact that is
run from directory containing `airflow` directory, that's why we need
to `cd` into pip's `site-packages` directory.
Also note that script will run `npm install` which is why I'm deleting
`node_modules` folder as it would increase Docker image size unnecessarily.

Noteable mentions:
- We now check the tarball checksum
- Bumped base image to latest stable version: `python:3.6-slim` => `python:3.7-slim`
- Run an `$ apt-get dist-upgrade` after the `$ apt-get update` to be sure OS packages are up-to-date and potentially have less security vulnerabilities
- Also upgraded `fab_oidc` from `0.0.5` => `0.0.6` (latest version)

[`compile_assets.sh`]: https://github.com/apache/airflow/blob/1.10.2/airflow/www_rbac/compile_assets.sh
[this article]: https://tecadmin.net/install-latest-nodejs-npm-on-debian/