### PR TITLE
airflow 1.10.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,7 +38,7 @@ ARG AIRFLOW_FILENAME="${AIRFLOW_VERSION}.zip"
 ARG AIRFLOW_TARBALL_URL="https://github.com/${AIRFLOW_REPO}/archive/${AIRFLOW_FILENAME}"
 RUN curl -o ${AIRFLOW_FILENAME} --location ${AIRFLOW_TARBALL_URL} && \
     echo "${AIRFLOW_SHA}  ${AIRFLOW_FILENAME}" | shasum --check - && \
-    SLUGIFY_USES_TEXT_UNIDECODE=yes pip install file:///./${AIRFLOW_FILENAME}#egg=apache-airflow[kubernetes,postgres] fab_oidc==0.0.6 redis==2.10.6 && \
+    SLUGIFY_USES_TEXT_UNIDECODE=yes pip install file:///./${AIRFLOW_FILENAME}#egg=apache-airflow[kubernetes,postgres] fab_oidc==0.0.8 redis==2.10.6 && \
     rm ${AIRFLOW_FILENAME}
 
 # install Node.js 10 LTS from official Node.js PPA

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,12 +18,12 @@
 FROM python:3.7-slim
 
 ARG AIRFLOW_REPO="apache/airflow"
-ARG AIRFLOW_VERSION="1.10.2"
-ARG AIRFLOW_SHA="6418cf5cabf830212892fe5b3f02c43efb316e93"
+ARG AIRFLOW_VERSION="1.10.3"
+ARG AIRFLOW_SHA="25a9f38fed609cefbb1904057270235ebe4d10fd"
 
 
 # install deps
-RUN apt-get update -y && apt-get dist-upgrade && apt-get install -y \
+RUN apt-get update -y && apt-get dist-upgrade -y && apt-get install -y \
     python-dev \
     build-essential \
     libssl-dev \


### PR DESCRIPTION
From the look of the changelog it doesn't seem like there is any breaking
changes (it's a minor release).

**CHANGELOG**: https://github.com/apache/airflow/blob/master/CHANGELOG.txt

Also:
- [added the `-y` flag](https://github.com/ministryofjustice/analytics-platform-airflow-docker-image/commit/35e4563f9b3ef9b1930b382d745550dacfa5674d#diff-3254677a7917c6c01f55212f86c57fbfR26) to `apt-get dist-upgrade` which was failing locally without it for some reason
- [Bumped](https://github.com/ministryofjustice/analytics-platform-airflow-docker-image/commit/94e60373d21a23f22a6188fc266dff296594fde5) `fab_oidc` to version 0.0.8

**Ticket**: https://trello.com/c/nQ5yJYg8/207-upgrade-airflow-to-1103